### PR TITLE
this plugin works well with ServerEngine 2.x

### DIFF
--- a/fluent-plugin-multiprocess.gemspec
+++ b/fluent-plugin-multiprocess.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.license = "Apache 2.0"
 
   gem.add_dependency "fluentd", [">= 0.10.0", "< 2"]
-  gem.add_dependency "serverengine", "~> 1.6"
+  gem.add_dependency "serverengine", ">= 1.6"
   gem.add_development_dependency "rake", ">= 0.9.2"
 end


### PR DESCRIPTION
This change is to make this plugin to work well with Fluentd v0.14.x using ServerEngine 2.x.

Fixes #11.
