### PR TITLE
doc: add contents about assumed Fluentd version

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,6 @@ Daemonized fluentd closes its STDOUT. So child processes on daemonized fluentd &
 ### NOTE
 
 You should use unique parameter in each sub configuration to avoid conflict problem, e.g. buffer_path of `buf_file`, `s3_object_key_format` of `out_s3` and more.
+
+This plugin is mainly for Fluentd v0.x, since Fluentd v1.x has [multi-process-workers feature](https://docs.fluentd.org/deployment/multi-process-workers).
+However, you can still use this plugin for Fluentd v1.x to run plugins that don't support the feature in multiple processes (with special care of the configuration to avoid race).

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Daemonized fluentd closes its STDOUT. So child processes on daemonized fluentd &
 
 ### NOTE
 
-You should use unique parameter in each sub configuration to avoid conflict problem, e.g. buffer_path of `buf_file`, `s3_object_key_format` of `out_s3` and more.
-
-This plugin is mainly for Fluentd v0.x, since Fluentd v1.x has [multi-process-workers feature](https://docs.fluentd.org/deployment/multi-process-workers).
+* You should use unique parameter in each sub configuration to avoid conflict problem, e.g. buffer_path of `buf_file`, `s3_object_key_format` of `out_s3` and more.
+* This plugin is mainly for Fluentd v0.x, since Fluentd v1.x has [multi-process-workers feature](https://docs.fluentd.org/deployment/multi-process-workers).
 However, you can still use this plugin for Fluentd v1.x to run plugins that don't support the feature in multiple processes (with special care of the configuration to avoid race).


### PR DESCRIPTION
Issue: #17 

Some users were wondering how to use this plugin for Fluentd v1.x, so how about adding this kind of explanation to the README?